### PR TITLE
Revert "Bump rand from 0.8.5 to 0.9.3 in the cargo group across 1 directory"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-glue"
-version = "0.1.16"
+version = "0.1.15"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -247,7 +247,7 @@ dependencies = [
  "crypto-common 0.1.7",
  "crypto-common 0.2.0",
  "der",
- "digest 0.11.0-rc.12",
+ "digest 0.11.0-rc.11",
  "ecdsa",
  "elliptic-curve",
  "generic-array",
@@ -262,7 +262,7 @@ dependencies = [
  "p521",
  "pbkdf2",
  "pkcs8",
- "rand 0.9.3",
+ "rand",
  "rsa",
  "rustls",
  "rustls-rustcrypto",
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.12"
+version = "0.11.0-rc.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b37eb2004a3548553a44cc1e688aac70f0345b896c9d822b4a0e520bc9183b"
+checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
 dependencies = [
  "block-buffer 0.11.0",
  "crypto-common 0.2.0",
@@ -536,7 +536,7 @@ version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
- "digest 0.11.0-rc.12",
+ "digest 0.11.0-rc.11",
 ]
 
 [[package]]
@@ -576,7 +576,7 @@ version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ac93c9768b8d587407881c98b0c3a5d3e3049daa73408ebe5bfb1ab1cb9c84"
 dependencies = [
- "digest 0.11.0-rc.12",
+ "digest 0.11.0-rc.11",
 ]
 
 [[package]]
@@ -626,7 +626,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "zeroize",
 ]
@@ -862,18 +862,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_chacha 0.3.1",
+ "libc",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -887,31 +878,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1153,7 +1125,7 @@ checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.12",
+ "digest 0.11.0-rc.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ p384 = "0.13"
 p521 = "0.13"
 pbkdf2 = "0.12"
 pkcs8 = { version = "0.10.2", features = ["encryption"] }
-rand = "0.9.3"
+rand = "0.8.4"
 rsa = { version = "0.9.10", features = ["sha2", "pem"] }
 
 sec1 = "0.7.3"


### PR DESCRIPTION
Reverts kanidm/crypto-glue#26

This breaks the build (and we don't have CI for it), eg:

```
error[E0277]: the trait bound `ThreadRng: CryptoRngCore` is not satisfied
   --> src/lib.rs:702:37
    |
702 |         EcdsaP521PrivateKey::random(&mut rng)
    |         --------------------------- ^^^^^^^^ the trait `crypto_common::rand_core::RngCore` is not implemented for `ThreadRng`
    |         |
    |         required by a bound introduced by this call
    |
note: there are multiple different versions of crate `rand_core` in the dependency graph
```



