### PR TITLE
Build and test the library in CI, fix tests on Windows, fix clippy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,7 @@ jobs:
           - &rust_oldest_version "1.88.0"
         os:
           - ubuntu-latest
-          # Tests are broken on Windows :(
-          # - windows-latest
+          - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: cargo check
 
       - name: clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --no-deps --all-targets --all-features
 
       - name: test
         run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: test
         run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: build
+
+on:
+  push:
+  pull_request:
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - run: cargo fmt --check
+
+  test:
+    name: test
+    strategy:
+      fail-fast: false
+      matrix:
+        # Single source of truth for minimum Rust in CI.
+        # Update this anchor value when bumping MSRV checks.
+        rust_version:
+          - stable
+          - &rust_oldest_version "1.88.0"
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: test
+        run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,5 +48,11 @@ jobs:
           components: clippy
       - uses: mozilla-actions/sccache-action@v0.0.10
 
+      - name: cargo check
+        run: cargo check
+
+      - name: clippy
+        run: cargo clippy --all-targets --all-features
+
       - name: test
         run: cargo test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
@@ -41,7 +41,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,8 @@ jobs:
           - &rust_oldest_version "1.88.0"
         os:
           - ubuntu-latest
-          - windows-latest
+          # Tests are broken on Windows :(
+          # - windows-latest
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "crypto-glue"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -247,7 +253,7 @@ dependencies = [
  "crypto-common 0.1.7",
  "crypto-common 0.2.0",
  "der",
- "digest 0.11.0-rc.11",
+ "digest 0.11.0-rc.12",
  "ecdsa",
  "elliptic-curve",
  "generic-array",
@@ -275,6 +281,7 @@ dependencies = [
  "subtle",
  "tracing",
  "tracing-subscriber",
+ "uds_windows",
  "uuid",
  "x509-cert",
  "zeroize",
@@ -354,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.11"
+version = "0.11.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b42f1d9edf5207c137646b568a0168ca0ec25b7f9eaf7f9961da51a3d91cea"
+checksum = "d4b37eb2004a3548553a44cc1e688aac70f0345b896c9d822b4a0e520bc9183b"
 dependencies = [
  "block-buffer 0.11.0",
  "crypto-common 0.2.0",
@@ -421,6 +428,22 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -536,7 +559,7 @@ version = "0.13.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef451d73f36d8a3f93ad32c332ea01146c9650e1ec821a9b0e46c01277d544f8"
 dependencies = [
- "digest 0.11.0-rc.11",
+ "digest 0.11.0-rc.12",
 ]
 
 [[package]]
@@ -576,7 +599,7 @@ version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ac93c9768b8d587407881c98b0c3a5d3e3049daa73408ebe5bfb1ab1cb9c84"
 dependencies = [
- "digest 0.11.0-rc.11",
+ "digest 0.11.0-rc.12",
 ]
 
 [[package]]
@@ -601,10 +624,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -947,6 +985,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,7 +1176,7 @@ checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.11.0-rc.11",
+ "digest 0.11.0-rc.12",
 ]
 
 [[package]]
@@ -1190,6 +1241,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1284,6 +1348,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,7 @@ rustls = { version = "0.23", default-features = false, features = ["custom-provi
 rustls-rustcrypto = "0.0.2-alpha"
 tracing-subscriber = "^0.3.20"
 
+[target.'cfg(windows)'.dev-dependencies]
+# For UnixStream on Windows
+# TODO: replace with stdlib when stable: https://github.com/rust-lang/rust/issues/150487
+uds_windows = "1.2.1"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,5 @@
+allow-expect-in-tests = true
+allow-unwrap-in-tests = false
+allow-panic-in-tests = true
+allow-dbg-in-tests = true
+allow-indexing-slicing-in-tests = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1010,7 +1010,7 @@ mod tests {
         let priv_key_info = PrivateKeyInfo::try_from(ecdsa_priv_key_der.as_bytes())
             .expect("Failed to parse private key info");
 
-        eprintln!("{:?}", priv_key_info);
+        eprintln!("{priv_key_info:?}");
     }
 
     #[cfg(any(unix, windows))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ pub mod hmac_s1 {
         hmac.finalize()
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     pub fn key_from_vec(bytes: Vec<u8>) -> Option<HmacSha1Key> {
         key_from_slice(&bytes)
     }
@@ -200,6 +201,7 @@ pub mod hmac_s256 {
         hmac.finalize()
     }
 
+    #[allow(clippy::needless_pass_by_value)]
     pub fn key_from_vec(bytes: Vec<u8>) -> Option<HmacSha256Key> {
         key_from_slice(&bytes)
     }
@@ -818,8 +820,10 @@ mod tests {
         // These are the "basic" encrypt/decrypt which postfixs a tag.
         let ciphertext = cipher
             .encrypt(&nonce, b"plaintext message".as_ref())
-            .unwrap();
-        let plaintext = cipher.decrypt(&nonce, ciphertext.as_ref()).unwrap();
+            .expect("Failed to encrypt message");
+        let plaintext = cipher
+            .decrypt(&nonce, ciphertext.as_ref())
+            .expect("Failed to decrypt message");
 
         assert_eq!(&plaintext, b"plaintext message");
 
@@ -835,11 +839,11 @@ mod tests {
 
         let tag = cipher
             .encrypt_in_place_detached(&nonce, associated_data, buffer.as_mut_slice())
-            .unwrap();
+            .expect("Failed to encrypt message");
 
         cipher
             .decrypt_in_place_detached(&nonce, associated_data, &mut buffer, &tag)
-            .unwrap();
+            .expect("Failed to decrypt message");
 
         assert_eq!(buffer, b"test message, super cool");
     }
@@ -873,10 +877,11 @@ mod tests {
         let key = aes256::new_key();
 
         let (mac, iv, ciphertext) =
-            aes256cbc::enc::<block_padding::Pkcs7>(&key, b"plaintext message").unwrap();
+            aes256cbc::enc::<block_padding::Pkcs7>(&key, b"plaintext message")
+                .expect("Failed to encrypt message");
 
-        let plaintext =
-            aes256cbc::dec::<block_padding::Pkcs7>(&key, &mac, &iv, &ciphertext).unwrap();
+        let plaintext = aes256cbc::dec::<block_padding::Pkcs7>(&key, &mac, &iv, &ciphertext)
+            .expect("Failed to decrypt message");
 
         assert_eq!(plaintext, b"plaintext message");
     }
@@ -893,12 +898,16 @@ mod tests {
         let mut wrapped_key = Aes256KwWrapped::default();
 
         // Wrap it.
-        key_wrap.wrap(&key_to_wrap, &mut wrapped_key).unwrap();
+        key_wrap
+            .wrap(&key_to_wrap, &mut wrapped_key)
+            .expect("Failed to wrap key");
         // Reverse the process
 
         let mut key_unwrapped = aes256::Aes256Key::default();
 
-        key_wrap.unwrap(&wrapped_key, &mut key_unwrapped).unwrap();
+        key_wrap
+            .unwrap(&wrapped_key, &mut key_unwrapped)
+            .expect("Failed to unwrap key");
 
         assert_eq!(key_to_wrap, key_unwrapped);
     }
@@ -908,15 +917,16 @@ mod tests {
         use crate::rsa::*;
         use crate::traits::*;
 
-        let pkey = new_key(MIN_BITS).unwrap();
+        let pkey = new_key(MIN_BITS).expect("Failed to generate RSA key");
 
         let pubkey = RS256PublicKey::from(&pkey);
 
         // OAEP
 
-        let ciphertext = oaep_sha256_encrypt(&pubkey, b"this is a message").unwrap();
+        let ciphertext =
+            oaep_sha256_encrypt(&pubkey, b"this is a message").expect("Failed to encrypt message");
 
-        let plaintext = oaep_sha256_decrypt(&pkey, &ciphertext).unwrap();
+        let plaintext = oaep_sha256_decrypt(&pkey, &ciphertext).expect("Failed to decrypt message");
 
         assert_eq!(plaintext, b"this is a message");
 
@@ -950,7 +960,7 @@ mod tests {
         // Can either sign data directly, using the correct associated hash type.
         let data = [0, 1, 2, 3, 4, 5, 6, 7];
 
-        let sig: EcdsaP256Signature = signer.try_sign(&data).unwrap();
+        let sig: EcdsaP256Signature = signer.try_sign(&data).expect("Failed to sign data");
 
         assert!(verifier.verify(&data, &sig).is_ok());
 
@@ -959,7 +969,9 @@ mod tests {
         let mut digest = EcdsaP256Digest::new();
         digest.update(data);
 
-        let sig: EcdsaP256Signature = signer.try_sign_digest(digest).unwrap();
+        let sig: EcdsaP256Signature = signer
+            .try_sign_digest(digest)
+            .expect("Failed to sign digest");
         assert!(verifier.verify(&data, &sig).is_ok());
     }
 
@@ -991,9 +1003,12 @@ mod tests {
         use pkcs8::PrivateKeyInfo;
 
         let ecdsa_priv_key = ecdsa_p256::new_key();
-        let ecdsa_priv_key_der = ecdsa_priv_key.to_pkcs8_der().unwrap();
+        let ecdsa_priv_key_der = ecdsa_priv_key
+            .to_pkcs8_der()
+            .expect("Failed to encode ECDSA private key");
 
-        let priv_key_info = PrivateKeyInfo::try_from(ecdsa_priv_key_der.as_bytes()).unwrap();
+        let priv_key_info = PrivateKeyInfo::try_from(ecdsa_priv_key_der.as_bytes())
+            .expect("Failed to parse private key info");
 
         eprintln!("{:?}", priv_key_info);
     }
@@ -1030,14 +1045,15 @@ mod tests {
         // CA SETUP
 
         let now = SystemTime::now();
-        let not_before = Time::try_from(now).unwrap();
-        let not_after = Time::try_from(now + Duration::new(3600, 0)).unwrap();
+        let not_before = Time::try_from(now).expect("Failed to convert system time to X509 time");
+        let not_after = Time::try_from(now + Duration::new(3600, 0))
+            .expect("Failed to convert system time to X509 time");
 
         let (root_signing_key, root_ca_cert) = build_test_ca_root(not_before, not_after);
 
         eprintln!("{}", X509Display::from(&root_ca_cert));
 
-        let subject = Name::from_str("CN=localhost").unwrap();
+        let subject = Name::from_str("CN=localhost").expect("Failed to parse subject name");
 
         let (server_key, server_csr) = build_test_csr(&subject);
 
@@ -1053,16 +1069,22 @@ mod tests {
 
         // ========================
         use p384::pkcs8::EncodePrivateKey;
-        let server_private_key_pkcs8_der = SecretKey::from(server_key).to_pkcs8_der().unwrap();
+        let server_private_key_pkcs8_der = SecretKey::from(server_key)
+            .to_pkcs8_der()
+            .expect("Failed to encode server private key");
 
-        let root_ca_cert_der = root_ca_cert.to_der().unwrap();
-        let server_cert_der = server_cert.to_der().unwrap();
+        let root_ca_cert_der = root_ca_cert
+            .to_der()
+            .expect("Failed to encode root CA certificate");
+        let server_cert_der = server_cert
+            .to_der()
+            .expect("Failed to encode server certificate");
 
         let mut ca_roots = RootCertStore::empty();
 
         ca_roots
             .add(CertificateDer::from(root_ca_cert_der.clone()))
-            .unwrap();
+            .expect("Failed to add root CA certificate");
 
         let server_chain = vec![
             CertificateDer::from(server_cert_der),
@@ -1076,14 +1098,14 @@ mod tests {
 
         let client_tls_config: Arc<_> = ClientConfig::builder_with_provider(provider.clone())
             .with_safe_default_protocol_versions()
-            .unwrap()
+            .expect("invalid protocol versions")
             .with_root_certificates(ca_roots)
             .with_no_client_auth()
             .into();
 
         let server_tls_config: Arc<_> = ServerConfig::builder_with_provider(provider)
             .with_safe_default_protocol_versions()
-            .unwrap()
+            .expect("invalid protocol versions")
             .with_no_client_auth()
             .with_single_cert(server_chain, server_private_key)
             .map(Arc::new)
@@ -1091,19 +1113,20 @@ mod tests {
 
         let server_name = ServerName::try_from("localhost").expect("invalid DNS name");
 
-        let (mut server_unix_stream, mut client_unix_stream) = UnixStream::pair().unwrap();
+        let (mut server_unix_stream, mut client_unix_stream) =
+            UnixStream::pair().expect("Failed to create UnixStream pair");
 
         let atomic = Arc::new(AtomicU16::new(0));
 
         let atomic_t = atomic.clone();
 
         let handle = std::thread::spawn(move || {
-            let mut client_connection =
-                ClientConnection::new(client_tls_config, server_name).unwrap();
+            let mut client_connection = ClientConnection::new(client_tls_config, server_name)
+                .expect("Failed to create client connection");
 
             let mut client = rustls::Stream::new(&mut client_connection, &mut client_unix_stream);
 
-            client.write_all(b"hello").unwrap();
+            client.write_all(b"hello").expect("Failed to write data");
 
             while atomic_t.load(Ordering::Relaxed) != 1 {
                 std::thread::sleep(std::time::Duration::from_millis(1));
@@ -1112,24 +1135,28 @@ mod tests {
             println!("THREAD DONE");
         });
 
-        let mut server_connection = ServerConnection::new(server_tls_config).unwrap();
+        let mut server_connection =
+            ServerConnection::new(server_tls_config).expect("Failed to create server connection");
 
         server_connection
             .complete_io(&mut server_unix_stream)
-            .unwrap();
+            .expect("Failed to complete TLS handshake");
 
         server_connection
             .complete_io(&mut server_unix_stream)
-            .unwrap();
+            .expect("Failed to complete TLS handshake");
 
         let mut buf: [u8; 5] = [0; 5];
-        server_connection.reader().read(&mut buf).unwrap();
+        server_connection
+            .reader()
+            .read_exact(&mut buf)
+            .expect("Failed to read data");
 
         assert_eq!(&buf, b"hello");
 
         atomic.store(1, Ordering::Relaxed);
 
         // If the thread paniced, this will panic.
-        handle.join().unwrap();
+        handle.join().expect("Thread panicked");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -998,6 +998,7 @@ mod tests {
         eprintln!("{:?}", priv_key_info);
     }
 
+    #[cfg(any(unix, windows))]
     #[test]
     fn rustls_mtls_basic() {
         use crate::test_ca::*;
@@ -1012,12 +1013,15 @@ mod tests {
         };
         use std::io::Read;
         use std::io::Write;
+        #[cfg(unix)]
         use std::os::unix::net::UnixStream;
         use std::str::FromStr;
         use std::sync::atomic::{AtomicU16, Ordering};
         use std::sync::Arc;
         use std::time::Duration;
         use std::time::SystemTime;
+        #[cfg(windows)]
+        use uds_windows::UnixStream;
         use x509_cert::der::Encode;
         use x509_cert::name::Name;
         use x509_cert::time::Time;

--- a/src/test_ca.rs
+++ b/src/test_ca.rs
@@ -87,7 +87,7 @@ pub(crate) fn build_test_ca_root(
         .expect("failed to build root CA certificate");
 
     // let cert_der = cert.to_der().expect("failed to encode root CA certificate as DER");
-    println!("{:?}", cert);
+    println!("{cert:?}");
 
     let cert_bytes = cert
         .tbs_certificate
@@ -112,7 +112,7 @@ pub(crate) fn build_test_ca_root(
         .expect("basic constraints not present");
 
     assert!(critical);
-    eprintln!("{:?}", basic_constraints);
+    eprintln!("{basic_constraints:?}");
 
     assert!(basic_constraints.ca);
     assert!(basic_constraints.path_len_constraint.is_none());
@@ -129,7 +129,7 @@ pub(crate) fn build_test_ca_root(
 
     assert!(critical);
 
-    eprintln!("{:?}", key_usage);
+    eprintln!("{key_usage:?}");
     let expected_key_usages = KeyUsages::KeyCertSign | KeyUsages::CRLSign;
     assert_eq!(key_usage, expected_key_usages.into());
 
@@ -141,7 +141,7 @@ pub(crate) fn build_test_ca_root(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", ca_subject_key_id);
+    eprintln!("{ca_subject_key_id:?}");
 
     //   Validity
     assert_eq!(
@@ -196,7 +196,7 @@ pub(crate) fn build_test_ca_int(
         update_bytes.copy_from_slice(int_serial_uuid.as_bytes());
     }
 
-    println!("{:?}", serial_bytes);
+    println!("{serial_bytes:?}");
     let serial_number =
         SerialNumber::new(&serial_bytes).expect("intermediate serial number should be valid");
 
@@ -271,7 +271,7 @@ pub(crate) fn build_test_ca_int(
     // let cert_der = int_cert
     //     .to_der()
     //     .expect("failed to encode intermediate CA certificate as DER");
-    println!("{:?}", int_cert);
+    println!("{int_cert:?}");
 
     let cert_bytes = int_cert
         .tbs_certificate
@@ -299,7 +299,7 @@ pub(crate) fn build_test_ca_int(
 
     assert!(critical);
 
-    eprintln!("{:?}", basic_constraints);
+    eprintln!("{basic_constraints:?}");
 
     assert!(basic_constraints.ca);
     assert_eq!(basic_constraints.path_len_constraint, Some(0));
@@ -317,7 +317,7 @@ pub(crate) fn build_test_ca_int(
 
     assert!(critical);
 
-    eprintln!("{:?}", key_usage);
+    eprintln!("{key_usage:?}");
     let expected_key_usages = KeyUsages::KeyCertSign | KeyUsages::CRLSign;
     assert_eq!(key_usage, expected_key_usages.into());
 
@@ -341,7 +341,7 @@ pub(crate) fn build_test_ca_int(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", authority_key_id);
+    eprintln!("{authority_key_id:?}");
 
     assert_eq!(
         authority_key_id
@@ -358,7 +358,7 @@ pub(crate) fn build_test_ca_int(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", int_subject_key_id);
+    eprintln!("{int_subject_key_id:?}");
 
     //   Validity
     assert_eq!(
@@ -424,7 +424,7 @@ pub(crate) fn build_test_csr(subject: &Name) -> (SigningKey, CertReq) {
     let client_cert_req_der = client_cert_req
         .to_der()
         .expect("failed to encode client certificate request as DER");
-    println!("{:?}", client_cert_req_der);
+    println!("{client_cert_req_der:?}");
 
     // First, extract the public key from the cert and use it to self-verify
 
@@ -488,7 +488,7 @@ pub(crate) fn test_ca_sign_client_csr(
         update_bytes.copy_from_slice(client_serial_uuid.as_bytes());
     }
 
-    println!("{:?}", serial_bytes);
+    println!("{serial_bytes:?}");
     let serial_number =
         SerialNumber::new(&serial_bytes).expect("client certificate serial number should be valid");
 
@@ -542,7 +542,7 @@ pub(crate) fn test_ca_sign_client_csr(
     // let client_cert_der = client_cert
     //     .to_der()
     //     .expect("failed to encode client certificate as DER");
-    println!("{:?}", client_cert);
+    println!("{client_cert:?}");
 
     // Client Leaf Cert
     //   Basic Constraints: critical
@@ -555,7 +555,7 @@ pub(crate) fn test_ca_sign_client_csr(
         .expect("basic constraints not present");
 
     assert!(critical);
-    eprintln!("{:?}", basic_constraints);
+    eprintln!("{basic_constraints:?}");
 
     assert!(!basic_constraints.ca);
 
@@ -572,7 +572,7 @@ pub(crate) fn test_ca_sign_client_csr(
 
     assert!(critical);
 
-    eprintln!("{:?}", key_usage);
+    eprintln!("{key_usage:?}");
     let expected_key_usages =
         KeyUsages::DigitalSignature | KeyUsages::NonRepudiation | KeyUsages::KeyEncipherment;
     assert_eq!(key_usage, expected_key_usages.into());
@@ -597,7 +597,7 @@ pub(crate) fn test_ca_sign_client_csr(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", authority_key_id);
+    eprintln!("{authority_key_id:?}");
 
     //   Subject Key ID
     let (_, int_subject_key_id) = ca_cert
@@ -621,7 +621,7 @@ pub(crate) fn test_ca_sign_client_csr(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", client_subject_key_id);
+    eprintln!("{client_subject_key_id:?}");
 
     //   Validity
     assert_eq!(
@@ -691,7 +691,7 @@ pub(crate) fn test_ca_sign_server_csr(
         update_bytes.copy_from_slice(server_serial_uuid.as_bytes());
     }
 
-    println!("{:?}", serial_bytes);
+    println!("{serial_bytes:?}");
     let serial_number =
         SerialNumber::new(&serial_bytes).expect("server certificate serial number should be valid");
 
@@ -744,7 +744,7 @@ pub(crate) fn test_ca_sign_server_csr(
     // let server_cert_der = server_cert
     //     .to_der()
     //     .expect("failed to encode server certificate as DER");
-    println!("{:?}", server_cert);
+    println!("{server_cert:?}");
 
     // VALIDATION NOW
 
@@ -759,7 +759,7 @@ pub(crate) fn test_ca_sign_server_csr(
         .expect("basic constraints not present");
 
     assert!(critical);
-    eprintln!("{:?}", basic_constraints);
+    eprintln!("{basic_constraints:?}");
 
     assert!(!basic_constraints.ca);
 
@@ -777,7 +777,7 @@ pub(crate) fn test_ca_sign_server_csr(
 
     assert!(critical);
 
-    eprintln!("{:?}", key_usage);
+    eprintln!("{key_usage:?}");
     let expected_key_usages = KeyUsages::DigitalSignature
         | KeyUsages::NonRepudiation
         | KeyUsages::KeyAgreement
@@ -804,7 +804,7 @@ pub(crate) fn test_ca_sign_server_csr(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", authority_key_id);
+    eprintln!("{authority_key_id:?}");
 
     //   Subject Key ID
     let (_, int_subject_key_id) = ca_cert
@@ -828,7 +828,7 @@ pub(crate) fn test_ca_sign_server_csr(
         .expect("failed to get extensions")
         .expect("key usage not present");
 
-    eprintln!("{:?}", server_subject_key_id);
+    eprintln!("{server_subject_key_id:?}");
 
     //   Validity
     assert_eq!(

--- a/src/test_ca.rs
+++ b/src/test_ca.rs
@@ -678,7 +678,9 @@ pub(crate) fn test_ca_sign_server_csr(
         .add_extension(&san)
         .expect("Unable to add extension");
 
-    let server_cert = builder.build_with_rng::<DerSignature>(&mut rng).unwrap();
+    let server_cert = builder
+        .build_with_rng::<DerSignature>(&mut rng)
+        .expect("Failed to build server certificate");
 
     // let server_cert_der = server_cert.to_der().unwrap();
     println!("{:?}", server_cert);
@@ -751,7 +753,10 @@ pub(crate) fn test_ca_sign_server_csr(
         .expect("key usage not present");
 
     assert_eq!(
-        authority_key_id.key_identifier.as_ref().unwrap(),
+        authority_key_id
+            .key_identifier
+            .as_ref()
+            .expect("Failed to get authority key identifier"),
         int_subject_key_id.as_ref()
     );
 
@@ -799,7 +804,8 @@ pub(crate) fn test_ca_sign_server_csr(
     );
     println!("{:?}", server_serial_uuid.as_bytes());
     let verify_serial =
-        Uuid::from_slice(&server_cert.tbs_certificate.serial_number.as_bytes()[1..]).unwrap();
+        Uuid::from_slice(&server_cert.tbs_certificate.serial_number.as_bytes()[1..])
+            .expect("Failed to parse server certificate serial number");
 
     assert_eq!(server_serial_uuid, verify_serial);
     //   Subject
@@ -811,8 +817,9 @@ pub(crate) fn test_ca_sign_server_csr(
 #[test]
 fn test_ca_build_process() {
     let now = SystemTime::now();
-    let not_before = Time::try_from(now).unwrap();
-    let not_after = Time::try_from(now + Duration::new(3600, 0)).unwrap();
+    let not_before = Time::try_from(now).expect("Failed to convert SystemTime to Time");
+    let not_after =
+        Time::try_from(now + Duration::new(3600, 0)).expect("Failed to convert SystemTime to Time");
 
     let (root_signing_key, root_ca_cert) = build_test_ca_root(not_before, not_after);
 
@@ -823,7 +830,7 @@ fn test_ca_build_process() {
 
     // =========================================================================================
 
-    let subject = Name::from_str("CN=multi pass").unwrap();
+    let subject = Name::from_str("CN=multi pass").expect("Failed to parse subject name");
 
     let (_client_key, client_csr) = build_test_csr(&subject);
 
@@ -837,7 +844,7 @@ fn test_ca_build_process() {
 
     // =========================================================================================
 
-    let subject = Name::from_str("CN=localhost").unwrap();
+    let subject = Name::from_str("CN=localhost").expect("Failed to parse subject name");
 
     let (_server_key, server_csr) = build_test_csr(&subject);
 

--- a/src/test_ca.rs
+++ b/src/test_ca.rs
@@ -46,7 +46,8 @@ pub(crate) fn build_test_ca_root(
     };
 
     let profile = Profile::Root;
-    let root_subject = Name::from_str("CN=Oh no he is writing a CA,O=Pls Help,C=AU").unwrap();
+    let root_subject = Name::from_str("CN=Oh no he is writing a CA,O=Pls Help,C=AU")
+        .expect("static root CA subject name should be valid");
 
     let signing_key = SigningKey::random(&mut rng);
     let verifying_key = VerifyingKey::from(&signing_key); // Serialize with `::to_encoded_point()`
@@ -65,7 +66,10 @@ pub(crate) fn build_test_ca_root(
     let dist_points = vec![DistributionPoint {
         distribution_point: Some(DistributionPointName::FullName(vec![
             GeneralName::UniformResourceIdentifier(
-                "https://example.com/crl".to_string().try_into().unwrap(),
+                "https://example.com/crl"
+                    .to_string()
+                    .try_into()
+                    .expect("static root CRL URI should be valid"),
             ),
         ])),
         reasons: None,
@@ -78,15 +82,23 @@ pub(crate) fn build_test_ca_root(
         .add_extension(&crl_extension)
         .expect("Unable to add extension");
 
-    let cert = builder.build_with_rng::<DerSignature>(&mut rng).unwrap();
+    let cert = builder
+        .build_with_rng::<DerSignature>(&mut rng)
+        .expect("failed to build root CA certificate");
 
-    // let cert_der = cert.to_der().unwrap();
+    // let cert_der = cert.to_der().expect("failed to encode root CA certificate as DER");
     println!("{:?}", cert);
 
-    let cert_bytes = cert.tbs_certificate.to_der().unwrap();
+    let cert_bytes = cert
+        .tbs_certificate
+        .to_der()
+        .expect("failed to encode root CA TBS certificate as DER");
 
-    let byte_sig: &[u8] = cert.signature.as_bytes().unwrap();
-    let cert_sig = DerSignature::try_from(byte_sig).unwrap();
+    let byte_sig: &[u8] = cert
+        .signature
+        .as_bytes()
+        .expect("root CA signature should be byte-aligned");
+    let cert_sig = DerSignature::try_from(byte_sig).expect("failed to parse root CA DER signature");
     assert!(verifying_key.verify(&cert_bytes, &cert_sig).is_ok());
 
     // For a root cert we must validate
@@ -148,8 +160,8 @@ pub(crate) fn build_test_ca_root(
     //   Serial Number - We have to drop the first byte.
     println!("{:?}", &cert.tbs_certificate.serial_number.as_bytes()[1..]);
     println!("{:?}", root_serial_uuid.as_bytes());
-    let verify_serial =
-        Uuid::from_slice(&cert.tbs_certificate.serial_number.as_bytes()[1..]).unwrap();
+    let verify_serial = Uuid::from_slice(&cert.tbs_certificate.serial_number.as_bytes()[1..])
+        .expect("failed to parse root CA certificate serial number as UUID");
 
     assert_eq!(root_serial_uuid, verify_serial);
 
@@ -185,7 +197,8 @@ pub(crate) fn build_test_ca_int(
     }
 
     println!("{:?}", serial_bytes);
-    let serial_number = SerialNumber::new(&serial_bytes).unwrap();
+    let serial_number =
+        SerialNumber::new(&serial_bytes).expect("intermediate serial number should be valid");
 
     let validity = Validity {
         not_before,
@@ -196,7 +209,8 @@ pub(crate) fn build_test_ca_int(
         issuer: root_ca_cert.tbs_certificate.subject.clone(),
         path_len_constraint: Some(0),
     };
-    let int_subject = Name::from_str("CN=Oh no its an intermediate,C=AU").unwrap();
+    let int_subject = Name::from_str("CN=Oh no its an intermediate,C=AU")
+        .expect("static intermediate CA subject name should be valid");
 
     let int_signing_key = SigningKey::random(&mut rng);
     let int_verifying_key = VerifyingKey::from(&int_signing_key); // Serialize with `::to_encoded_point()`
@@ -219,7 +233,7 @@ pub(crate) fn build_test_ca_int(
                 "https://example.com/int/crl"
                     .to_string()
                     .try_into()
-                    .unwrap(),
+                    .expect("static intermediate CRL URI should be valid"),
             ),
         ])),
         reasons: None,
@@ -234,7 +248,12 @@ pub(crate) fn build_test_ca_int(
 
     let name_constraint_extension = NameConstraints {
         permitted_subtrees: Some(vec![GeneralSubtree {
-            base: GeneralName::DnsName("example.com".to_string().try_into().unwrap()),
+            base: GeneralName::DnsName(
+                "example.com"
+                    .to_string()
+                    .try_into()
+                    .expect("static intermediate DNS name constraint should be valid"),
+            ),
             minimum: 0,
             maximum: None,
         }]),
@@ -245,15 +264,26 @@ pub(crate) fn build_test_ca_int(
         .add_extension(&name_constraint_extension)
         .expect("Unable to add extension");
 
-    let int_cert = builder.build_with_rng::<DerSignature>(&mut rng).unwrap();
+    let int_cert = builder
+        .build_with_rng::<DerSignature>(&mut rng)
+        .expect("failed to build intermediate CA certificate");
 
-    // let cert_der = int_cert.to_der().unwrap();
+    // let cert_der = int_cert
+    //     .to_der()
+    //     .expect("failed to encode intermediate CA certificate as DER");
     println!("{:?}", int_cert);
 
-    let cert_bytes = int_cert.tbs_certificate.to_der().unwrap();
+    let cert_bytes = int_cert
+        .tbs_certificate
+        .to_der()
+        .expect("failed to encode intermediate CA TBS certificate as DER");
 
-    let byte_sig: &[u8] = int_cert.signature.as_bytes().unwrap();
-    let cert_sig = DerSignature::try_from(byte_sig).unwrap();
+    let byte_sig: &[u8] = int_cert
+        .signature
+        .as_bytes()
+        .expect("intermediate CA signature should be byte-aligned");
+    let cert_sig =
+        DerSignature::try_from(byte_sig).expect("failed to parse intermediate CA DER signature");
     assert!(root_verifying_key.verify(&cert_bytes, &cert_sig).is_ok());
 
     // Intermediate:
@@ -314,7 +344,10 @@ pub(crate) fn build_test_ca_int(
     eprintln!("{:?}", authority_key_id);
 
     assert_eq!(
-        authority_key_id.key_identifier.as_ref().unwrap(),
+        authority_key_id
+            .key_identifier
+            .as_ref()
+            .expect("intermediate CA should include authority key identifier"),
         root_subject_key_id.as_ref()
     );
 
@@ -360,8 +393,8 @@ pub(crate) fn build_test_ca_int(
         &int_cert.tbs_certificate.serial_number.as_bytes()[1..]
     );
     println!("{:?}", int_serial_uuid.as_bytes());
-    let verify_serial =
-        Uuid::from_slice(&int_cert.tbs_certificate.serial_number.as_bytes()[1..]).unwrap();
+    let verify_serial = Uuid::from_slice(&int_cert.tbs_certificate.serial_number.as_bytes()[1..])
+        .expect("failed to parse intermediate CA certificate serial number as UUID");
 
     assert_eq!(int_serial_uuid, verify_serial);
 
@@ -384,9 +417,13 @@ pub(crate) fn build_test_csr(subject: &Name) -> (SigningKey, CertReq) {
     let builder = RequestBuilder::new(subject.clone(), &client_signing_key)
         .expect("Create certificate request");
 
-    let client_cert_req = builder.build_with_rng::<DerSignature>(&mut rng).unwrap();
+    let client_cert_req = builder
+        .build_with_rng::<DerSignature>(&mut rng)
+        .expect("failed to build client certificate request");
 
-    let client_cert_req_der = client_cert_req.to_der().unwrap();
+    let client_cert_req_der = client_cert_req
+        .to_der()
+        .expect("failed to encode client certificate request as DER");
     println!("{:?}", client_cert_req_der);
 
     // First, extract the public key from the cert and use it to self-verify
@@ -397,16 +434,27 @@ pub(crate) fn build_test_csr(subject: &Name) -> (SigningKey, CertReq) {
     println!("--> {:?}", &spki);
 
     let extracted_public_key = VerifyingKey::from_public_key_der(
-        // spki.subject_public_key.as_bytes().unwrap()
-        spki.to_der().unwrap().as_slice(),
+        // spki.subject_public_key
+        //     .as_bytes()
+        //     .expect("client CSR subject public key should be byte-aligned")
+        spki.to_der()
+            .expect("failed to encode client CSR public key as DER")
+            .as_slice(),
     )
     .expect("Unable to parse key bytes");
     assert_eq!(extracted_public_key, client_verifying_key);
 
-    let req_bytes = client_cert_req.info.to_der().unwrap();
+    let req_bytes = client_cert_req
+        .info
+        .to_der()
+        .expect("failed to encode client CSR info as DER");
 
-    let byte_sig: &[u8] = client_cert_req.signature.as_bytes().unwrap();
-    let client_cert_req_sig = DerSignature::try_from(byte_sig).unwrap();
+    let byte_sig: &[u8] = client_cert_req
+        .signature
+        .as_bytes()
+        .expect("client CSR signature should be byte-aligned");
+    let client_cert_req_sig =
+        DerSignature::try_from(byte_sig).expect("failed to parse client CSR DER signature");
     assert!(extracted_public_key
         .verify(&req_bytes, &client_cert_req_sig)
         .is_ok());
@@ -441,7 +489,8 @@ pub(crate) fn test_ca_sign_client_csr(
     }
 
     println!("{:?}", serial_bytes);
-    let serial_number = SerialNumber::new(&serial_bytes).unwrap();
+    let serial_number =
+        SerialNumber::new(&serial_bytes).expect("client certificate serial number should be valid");
 
     let validity = Validity {
         not_before,
@@ -477,7 +526,8 @@ pub(crate) fn test_ca_sign_client_csr(
         .add_extension(&eku_extension)
         .expect("Unable to add extension");
 
-    let alt_name = Name::from_str("ENTRYUUID=cb98d3d3-efcc-4675-ad40-435f6280d41b").unwrap();
+    let alt_name = Name::from_str("ENTRYUUID=cb98d3d3-efcc-4675-ad40-435f6280d41b")
+        .expect("static client certificate directoryName SAN should be valid");
 
     let san = SubjectAltName(vec![GeneralName::DirectoryName(alt_name)]);
 
@@ -485,9 +535,13 @@ pub(crate) fn test_ca_sign_client_csr(
         .add_extension(&san)
         .expect("Unable to add extension");
 
-    let client_cert = builder.build_with_rng::<DerSignature>(&mut rng).unwrap();
+    let client_cert = builder
+        .build_with_rng::<DerSignature>(&mut rng)
+        .expect("failed to build client certificate");
 
-    // let client_cert_der = client_cert.to_der().unwrap();
+    // let client_cert_der = client_cert
+    //     .to_der()
+    //     .expect("failed to encode client certificate as DER");
     println!("{:?}", client_cert);
 
     // Client Leaf Cert
@@ -553,7 +607,10 @@ pub(crate) fn test_ca_sign_client_csr(
         .expect("key usage not present");
 
     assert_eq!(
-        authority_key_id.key_identifier.as_ref().unwrap(),
+        authority_key_id
+            .key_identifier
+            .as_ref()
+            .expect("client certificate should include authority key identifier"),
         int_subject_key_id.as_ref()
     );
 
@@ -601,7 +658,8 @@ pub(crate) fn test_ca_sign_client_csr(
     );
     println!("{:?}", client_serial_uuid.as_bytes());
     let verify_serial =
-        Uuid::from_slice(&client_cert.tbs_certificate.serial_number.as_bytes()[1..]).unwrap();
+        Uuid::from_slice(&client_cert.tbs_certificate.serial_number.as_bytes()[1..])
+            .expect("failed to parse client certificate serial number as UUID");
 
     assert_eq!(client_serial_uuid, verify_serial);
     //   Subject
@@ -634,7 +692,8 @@ pub(crate) fn test_ca_sign_server_csr(
     }
 
     println!("{:?}", serial_bytes);
-    let serial_number = SerialNumber::new(&serial_bytes).unwrap();
+    let serial_number =
+        SerialNumber::new(&serial_bytes).expect("server certificate serial number should be valid");
 
     let validity = Validity {
         not_before,
@@ -670,7 +729,7 @@ pub(crate) fn test_ca_sign_server_csr(
         .add_extension(&eku_extension)
         .expect("Unable to add extension");
 
-    let alt_name = Ia5String::new("localhost").unwrap();
+    let alt_name = Ia5String::new("localhost").expect("static server DNS SAN should be valid");
 
     let san = SubjectAltName(vec![GeneralName::DnsName(alt_name)]);
 
@@ -682,7 +741,9 @@ pub(crate) fn test_ca_sign_server_csr(
         .build_with_rng::<DerSignature>(&mut rng)
         .expect("Failed to build server certificate");
 
-    // let server_cert_der = server_cert.to_der().unwrap();
+    // let server_cert_der = server_cert
+    //     .to_der()
+    //     .expect("failed to encode server certificate as DER");
     println!("{:?}", server_cert);
 
     // VALIDATION NOW

--- a/src/x509/chain.rs
+++ b/src/x509/chain.rs
@@ -403,15 +403,16 @@ mod tests {
         let _ = tracing_subscriber::fmt::try_init();
 
         let now = SystemTime::now();
-        let not_before = Time::try_from(now).unwrap();
-        let not_after = Time::try_from(now + Duration::new(3600, 0)).unwrap();
+        let not_before = Time::try_from(now).expect("Failed to convert SystemTime to Time");
+        let not_after = Time::try_from(now + Duration::new(3600, 0))
+            .expect("Failed to convert SystemTime to Time");
 
         let (root_signing_key, root_ca_cert) = build_test_ca_root(not_before, not_after);
 
         let (int_signing_key, int_ca_cert) =
             build_test_ca_int(not_before, not_after, &root_signing_key, &root_ca_cert);
 
-        let subject = Name::from_str("CN=localhost").unwrap();
+        let subject = Name::from_str("CN=localhost").expect("Failed to parse subject name");
         let (server_key, server_csr) = build_test_csr(&subject);
 
         let server_cert = test_ca_sign_server_csr(
@@ -448,17 +449,20 @@ mod tests {
 
         let verifier = EcdsaP384PublicKey::try_from(subject_public_key_info)
             .map(EcdsaP384VerifyingKey::from)
-            .unwrap();
+            .expect("Failed to create EcdsaP384VerifyingKey");
 
-        verifier.verify(&test_data, &test_data_signature).unwrap();
+        verifier
+            .verify(&test_data, &test_data_signature)
+            .expect("Failed to verify test data signature");
     }
 
     #[test]
     fn x509_chain_verify_rsa_fido_mds() {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let global_sign_root_cert = Certificate::from_pem(GLOBAL_SIGN_ROOT).unwrap();
-        let mds_cert = Certificate::from_pem(FIDO_MDS).unwrap();
+        let global_sign_root_cert =
+            Certificate::from_pem(GLOBAL_SIGN_ROOT).expect("Failed to parse GlobalSign Root cert");
+        let mds_cert = Certificate::from_pem(FIDO_MDS).expect("Failed to parse FIDO MDS cert");
 
         let ca_store = X509Store::new(&[global_sign_root_cert]);
 
@@ -480,8 +484,10 @@ mod tests {
     fn x509_chain_verify_rsa_yubico_u2f() {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let yubico_u2f_root_cert = Certificate::from_pem(YUBICO_U2F_ROOT).unwrap();
-        let yubico_device_attest = Certificate::from_pem(YUBICO_DEVICE_ATTEST).unwrap();
+        let yubico_u2f_root_cert =
+            Certificate::from_pem(YUBICO_U2F_ROOT).expect("Failed to parse Yubico U2F Root cert");
+        let yubico_device_attest = Certificate::from_pem(YUBICO_DEVICE_ATTEST)
+            .expect("Failed to parse Yubico Device Attest cert");
 
         let ca_store = X509Store::new(&[yubico_u2f_root_cert]);
 

--- a/src/x509/display.rs
+++ b/src/x509/display.rs
@@ -130,7 +130,7 @@ impl fmt::Display for X509Display<'_> {
             &const_oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION => {
                 writeln!(f, "sha256-with-rsa-encryption")?
             }
-            oid => writeln!(f, "OID= {:?}", oid)?,
+            oid => writeln!(f, "OID= {oid:?}")?,
         }
 
         // SUBJECT PUBLIC KEY
@@ -367,9 +367,8 @@ impl fmt::Display for X509Display<'_> {
                     // Probably in RFC5280
                     writeln!(
                         f,
-                        "{:indent$}Unknown Extension: OID= {:?}",
+                        "{:indent$}Unknown Extension: OID= {oid:?}",
                         "",
-                        oid,
                         indent = INDENT_TWO
                     )?
                 }
@@ -384,7 +383,7 @@ impl fmt::Display for X509Display<'_> {
             &const_oid::db::rfc5912::SHA_256_WITH_RSA_ENCRYPTION => {
                 writeln!(f, "sha256-with-rsa-encryption")?
             }
-            oid => writeln!(f, "OID= {:?}", oid)?,
+            oid => writeln!(f, "OID= {oid:?}")?,
         }
 
         writeln!(f, "{:indent$}Signature:", "", indent = INDENT)?;
@@ -418,7 +417,7 @@ impl fmt::Display for BytesDisplay<'_> {
 
         let mut count = 0;
         while let Some(byte) = iter.next() {
-            write!(f, "{:02x}", byte)?;
+            write!(f, "{byte:02x}")?;
 
             count += 1;
 
@@ -498,7 +497,7 @@ impl fmt::Display for SubjectPublicKeyDisplay<'_> {
 
         match alg_oid {
             &const_oid::db::rfc5912::ID_EC_PUBLIC_KEY => writeln!(f, "id-ec-public-key")?,
-            oid => writeln!(f, "OID= {:?}", oid)?,
+            oid => writeln!(f, "OID= {oid:?}")?,
         }
 
         if let Ok(param_oid) = self.spki.algorithm.parameters_oid() {
@@ -506,7 +505,7 @@ impl fmt::Display for SubjectPublicKeyDisplay<'_> {
             match param_oid {
                 const_oid::db::rfc5912::SECP_384_R_1 => writeln!(f, "SEC P384 R1")?,
                 const_oid::db::rfc5912::SECP_256_R_1 => writeln!(f, "SEC P256 R1")?,
-                oid => writeln!(f, "OID= {:?}", oid)?,
+                oid => writeln!(f, "OID= {oid:?}")?,
             }
         }
 

--- a/src/x509/display.rs
+++ b/src/x509/display.rs
@@ -332,7 +332,7 @@ impl fmt::Display for X509Display<'_> {
                             &const_oid::db::rfc5280::ID_KP_CODE_SIGNING => {
                                 writeln!(f, "Code Signing")?
                             }
-                            oid => writeln!(f, "OID= {:?}", oid)?,
+                            oid => writeln!(f, "OID= {oid:?}")?,
                         }
                     }
                 }


### PR DESCRIPTION
* Build and test the library in CI, so that we can detect broken changes before they're merged (#27).
* Fix the tests on Windows, and disable UnixStream-based tests on platforms that don't support it (non-UNIX non-Windows).
* Fix clippy.