### PR TITLE
Build and test the library for WASM+JS environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,3 +56,28 @@ jobs:
 
       - name: test
         run: cargo test
+
+  wasm:
+    name: wasm
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      # Building the tests as we don't want to unconditionally use sources of
+      # time and entropy for WASM+JS environments.
+      - run: cargo build --target wasm32-unknown-unknown --tests
+
+      - name: Test on Chromium
+        run: wasm-pack test --headless --chrome
+
+      - name: Test on firefox
+        run: wasm-pack test --headless --firefox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    env:
+      SCCACHE_GHA_ENABLED: "false"
+      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         run: cargo test
 
   wasm:
-    name: wasm
+    name: WASM
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -82,5 +82,5 @@ jobs:
       - name: Test on Chromium
         run: wasm-pack test --headless --chrome
 
-      - name: Test on firefox
+      - name: Test on Firefox
         run: wasm-pack test --headless --firefox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,15 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    env:
-      SCCACHE_GHA_ENABLED: "false"
-      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
           targets: wasm32-unknown-unknown
+      - uses: mozilla-actions/sccache-action@v0.0.10
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +140,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbc"
@@ -257,6 +274,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "generic-array",
+ "getrandom 0.2.17",
  "hex",
  "hkdf",
  "hmac 0.12.1",
@@ -271,6 +289,7 @@ dependencies = [
  "rand",
  "rsa",
  "rustls",
+ "rustls-pki-types",
  "rustls-rustcrypto",
  "sec1",
  "serde",
@@ -283,6 +302,8 @@ dependencies = [
  "tracing-subscriber",
  "uds_windows",
  "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
  "x509-cert",
  "zeroize",
 ]
@@ -474,6 +495,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,8 +537,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -584,11 +631,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "js-sys"
-version = "0.3.85"
+name = "itoa"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -636,12 +691,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "minicov"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
+dependencies = [
+ "cc",
+ "walkdir",
 ]
 
 [[package]]
@@ -704,6 +775,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opaque-debug"
@@ -1016,6 +1093,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1087,6 +1165,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scrypt"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1144,6 +1232,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1203,6 +1304,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1406,6 +1513,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1434,10 +1551,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.108"
+name = "wasm-bindgen-futures"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1445,9 +1572,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1458,11 +1585,69 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
+dependencies = [
+ "async-trait",
+ "cast",
+ "js-sys",
+ "libm",
+ "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1624,3 +1809,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,14 +82,19 @@ tracing-subscriber = "^0.3.20"
 uds_windows = "1.2.1"
 
 [target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
-# Per https://docs.rs/getrandom/latest/getrandom/#webassembly-support, we don't want to add these
-# dependencies unconditionally, so these are dev-dependencies. The library's tests treat WASM
-# targets as "running in browser or Node.js so JS is available". If we start testing on something
-# that doesn't support JS, we'll need to revisit this.
-wasm-bindgen = { version = "0.2.121" }
-wasm-bindgen-test = "0.3.0"
-
-# Sources of time and entropy for tests.
+# Per https://docs.rs/getrandom/latest/getrandom/#webassembly-support, we don't want to add
+# dependencies for WASM+JS environments unconditionally to all WASM targets.
+#
+# However, we need these as dev-dependencies for the library's tests, which treats WASM as WASM+JS.
+# If we start testing on other WASM environments, we'll need to revisit this.
+#
+# Sources of time and entropy in a WASM+JS environment, enabling features in transitive dependencies
+# via feature unification. Binary users of this library will need something similar for their target
+# platform.
 getrandom = { version = "0.2.17", features = ["js"] }
 rustls-pki-types = { version = "1.14.0", features = ["web"] }
 uuid = { version = "1.20.0", features = ["js"] }
+
+# wasm-bindgen and wasm-bindgen-test are only directly used by tests.
+wasm-bindgen = { version = "0.2.121" }
+wasm-bindgen-test = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/kanidm/crypto-glue/"
 authors = ["William Brown <william@blackhats.net.au>"]
 
 [features]
-default = [ "alloc" ]
-alloc = [ "argon2/alloc" ]
+default = ["alloc"]
+alloc = ["argon2/alloc"]
 
 [profile.dev.package.num-bigint-dig]
 opt-level = 3
@@ -80,3 +80,16 @@ tracing-subscriber = "^0.3.20"
 # For UnixStream on Windows
 # TODO: replace with stdlib when stable: https://github.com/rust-lang/rust/issues/150487
 uds_windows = "1.2.1"
+
+[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
+# Per https://docs.rs/getrandom/latest/getrandom/#webassembly-support, we don't want to add these
+# dependencies unconditionally, so these are dev-dependencies. The library's tests treat WASM
+# targets as "running in browser or Node.js so JS is available". If we start testing on something
+# that doesn't support JS, we'll need to revisit this.
+wasm-bindgen = { version = "0.2.121" }
+wasm-bindgen-test = "0.3.0"
+
+# Sources of time and entropy for tests.
+getrandom = { version = "0.2.17", features = ["js"] }
+rustls-pki-types = { version = "1.14.0", features = ["web"] }
+uuid = { version = "1.20.0", features = ["js"] }

--- a/README.md
+++ b/README.md
@@ -20,3 +20,12 @@ pkcs8 crate as a trait, and without it in scope the documentation won't show me 
 
 Generally this means if you want something from the rustcrypto ecosystem, you can reach for your
 glue bottle instead, and trust that it has nice type aliases and all the features you need.
+
+## Platform-specific notes
+
+### WASM
+
+The default Rust `wasm32-unknown-unknown` target does not provide sources of time or entropy, which
+some of this crate's dependencies require.
+
+See [`Cargo.toml`](./Cargo.toml) for a list for WASM+JS (browser and Node.js) environments.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -767,7 +767,16 @@ pub mod pkcs8 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+    use wasm_bindgen_test::*;
+    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn sha256_basic() {
         use crate::s256::*;
         use crate::traits::*;
@@ -780,6 +789,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn hmac_256_basic() {
         use crate::hmac_s256::*;
         use crate::traits::Mac;
@@ -794,6 +807,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn hmac_512_basic() {
         use crate::hmac_s512::*;
 
@@ -807,6 +824,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn aes256gcm_basic() {
         use crate::aes256;
         use crate::aes256gcm::*;
@@ -849,6 +870,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn aes256cbc_basic() {
         use crate::aes256;
         use crate::aes256cbc::{self, *};
@@ -870,6 +895,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn aes256cbc_hmac_basic() {
         use crate::aes256;
         use crate::aes256cbc::{self, block_padding};
@@ -887,6 +916,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn aes256kw_basic() {
         use crate::aes256;
         use crate::aes256kw::*;
@@ -913,6 +946,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn rsa_basic() {
         use crate::rsa::*;
         use crate::traits::*;
@@ -946,6 +983,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn ecdsa_p256_basic() {
         use crate::ecdsa_p256::*;
         use crate::traits::*;
@@ -976,6 +1017,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn ecdh_p256_basic() {
         use crate::ecdh_p256::*;
 
@@ -995,6 +1040,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn pkcs8_handling_test() {
         use crate::ecdsa_p256;
         use crate::traits::Pkcs8EncodePrivateKey;
@@ -1034,7 +1083,6 @@ mod tests {
         use std::sync::atomic::{AtomicU16, Ordering};
         use std::sync::Arc;
         use std::time::Duration;
-        use std::time::SystemTime;
         #[cfg(windows)]
         use uds_windows::UnixStream;
         use x509_cert::der::Encode;
@@ -1044,7 +1092,7 @@ mod tests {
         // ========================
         // CA SETUP
 
-        let now = SystemTime::now();
+        let now = now();
         let not_before = Time::try_from(now).expect("Failed to convert system time to X509 time");
         let not_after = Time::try_from(now + Duration::new(3600, 0))
             .expect("Failed to convert system time to X509 time");

--- a/src/test_ca.rs
+++ b/src/test_ca.rs
@@ -55,9 +55,7 @@ pub fn now() -> SystemTime {
         }
 
         let now = now().unwrap_throw() as u64;
-        UNIX_EPOCH
-            .checked_add(Duration::from_millis(now))
-            .unwrap()
+        UNIX_EPOCH.checked_add(Duration::from_millis(now)).unwrap()
     }
 
     #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]

--- a/src/test_ca.rs
+++ b/src/test_ca.rs
@@ -31,6 +31,39 @@ use p384::ecdsa::{DerSignature, SigningKey};
 use crate::x509::uuid_to_serial;
 use uuid::Uuid;
 
+#[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+use wasm_bindgen_test::*;
+#[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// [`SystemTime::now`][] equivalent that uses `Date.now()` on WASM.
+#[cfg_attr(
+    not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))),
+    inline
+)]
+pub fn now() -> SystemTime {
+    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+    {
+        use std::time::{Duration, UNIX_EPOCH};
+        use wasm_bindgen::prelude::*;
+
+        #[wasm_bindgen]
+        extern "C" {
+            // NOTE: This signature works around https://bugzilla.mozilla.org/show_bug.cgi?id=1787770
+            #[wasm_bindgen(js_namespace = Date, catch)]
+            fn now() -> Result<f64, JsValue>;
+        }
+
+        let now = now().unwrap_throw() as u64;
+        UNIX_EPOCH
+            .checked_add(Duration::from_millis(now))
+            .unwrap()
+    }
+
+    #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+    SystemTime::now()
+}
+
 pub(crate) fn build_test_ca_root(
     not_before: Time,
     not_after: Time,
@@ -876,8 +909,12 @@ pub(crate) fn test_ca_sign_server_csr(
 }
 
 #[test]
+#[cfg_attr(
+    all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+    wasm_bindgen_test
+)]
 fn test_ca_build_process() {
-    let now = SystemTime::now();
+    let now = now();
     let not_before = Time::try_from(now).expect("Failed to convert SystemTime to Time");
     let not_after =
         Time::try_from(now + Duration::new(3600, 0)).expect("Failed to convert SystemTime to Time");

--- a/src/x509/chain.rs
+++ b/src/x509/chain.rs
@@ -398,11 +398,20 @@ mod tests {
     use std::time::Duration;
     use std::time::SystemTime;
 
+    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+    use wasm_bindgen_test::*;
+    #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))]
+    wasm_bindgen_test_configure!(run_in_browser);
+
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn x509_chain_verify_basic() {
         let _ = tracing_subscriber::fmt::try_init();
 
-        let now = SystemTime::now();
+        let now = now();
         let not_before = Time::try_from(now).expect("Failed to convert SystemTime to Time");
         let not_after = Time::try_from(now + Duration::new(3600, 0))
             .expect("Failed to convert SystemTime to Time");
@@ -457,6 +466,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn x509_chain_verify_rsa_fido_mds() {
         let _ = tracing_subscriber::fmt::try_init();
 
@@ -481,6 +494,10 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(
+        all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")),
+        wasm_bindgen_test
+    )]
     fn x509_chain_verify_rsa_yubico_u2f() {
         let _ = tracing_subscriber::fmt::try_init();
 
@@ -491,7 +508,7 @@ mod tests {
 
         let ca_store = X509Store::new(&[yubico_u2f_root_cert]);
 
-        let now = SystemTime::now();
+        let now = now();
         let leaf = &yubico_device_attest;
         let chain = [];
 


### PR DESCRIPTION
* Add test annotations for `wasm-pack`.
* Add a source of time for the tests on WASM+JS environments.
* Run WASM tests in CI.

Fixes #31 